### PR TITLE
Use PostgreSQL as the test database.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  adapter: postgresql
+  encoding: unicode
 
 production: &production
   <<: *default

--- a/test/controllers/import_controller_test.rb
+++ b/test/controllers/import_controller_test.rb
@@ -217,7 +217,10 @@ class ImportControllerTest < ActionController::TestCase
     }
     post :typeform, params_to_submit
     user = User.last
-    parsed_blob = JSON.parse(user.signup_blob, symbolize_names: true)
-    assert parsed_blob[:form_response][:answers].first[:field][:text] == 'foo'
+    parsed_response = JSON.parse(
+      user.signup_blob['form_response'].gsub('=>', ':'),
+      symbolize_names: true
+    )
+    assert parsed_response[:answers].first[:field][:text] == 'foo'
   end
 end


### PR DESCRIPTION
PostgreSQL is needed instead of SQLite because of the use of the `hstore`
datatype for User#signup_blob. Unfortunately this means that to run local tests
locally, you'll need a running PostgreSQL database.

On OSX this can be done by:

Installing PostgreSQL:

- Run `brew install postgresql`

- Run: `createdb`

This sets up a database. By default it'll be named after your username.

After that, to start PostgreSQL you can:

- Run `pg_ctl -D /usr/local/var/postgres start`

And then to stop PostgreSQL you can:

- Run `pg_ctl -D /usr/local/var/postgres stop`

It's a bit more intense than ideal and perhaps this is incentive enough against
using `hstore` in place of just dumping JSON and re-parsing it if necessary.

The `.gsub` shenanigans in the test is because `hstore` looks to only apply at
the first level and so hashes of hashes are flattened to Strings.