### PR TITLE
Rename filter method.

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,5 +1,6 @@
 class UserController < ApplicationController
-  before_filter :require_user, :only => :view
+  before_action :require_user, :only => :view
+
   def require_user
     puts "require user called"
     @user = User.find_by_url(params[:id])


### PR DESCRIPTION
This looks to have changed in Rails 4.2[0].

0. https://github.com/rails/rails/blob/81b2aed360221a2cb5419cc1e5fd697961a183a6/guides/source/4_2_release_notes.md#notable-changes-1